### PR TITLE
Feature/create control panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="/src/client/main.tsx"></script>
+    <script type="module" src="/src-new/client/main.tsx"></script>
   </body>
 </html>

--- a/src-new/client/app.css
+++ b/src-new/client/app.css
@@ -1,0 +1,9 @@
+.cartesian-svg line.grid-line {
+  stroke: #ddd;
+  stroke-width: 1;
+}
+
+.cartesian-svg line.grid-center-line {
+  stroke: #000;
+  stroke-width: 2;
+}

--- a/src-new/client/app.tsx
+++ b/src-new/client/app.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useState, useCallback } from 'preact/hooks'
+import './app.css';
+
+import Workspace from './components/Workspace'
+
+
+const App = () => {
+
+  // Grid Information
+  const PIXELS_PER_MM = 3;
+  const GRID_SIZE = 600;
+  const GRID_CENTER = GRID_SIZE / 2;
+
+  return (
+    <div class="app-wrapper">
+      <div class="workspace-wrapper">
+        <Workspace gridSize={GRID_SIZE} pixelsPerMm={3} />
+
+      </div>
+    </div>
+  )
+}
+
+export default App;

--- a/src-new/client/app.tsx
+++ b/src-new/client/app.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from 'preact/hooks'
 import './app.css';
 
 import Workspace from './components/Workspace'
+import ControlPanel from './components/Controlpanel';
 
 
 const App = () => {
@@ -11,8 +12,33 @@ const App = () => {
   const GRID_SIZE = 600;
   const GRID_CENTER = GRID_SIZE / 2;
 
+  const [frame, setFrame] = useState({
+    id: 'frame-1',
+    headtubeAngle: 73,
+  });
+
+  const [stem, setStem] = useState({
+    id: 'stem-1',
+    length: 100,
+    angle: 6,
+    stackHeight: 0,
+  })
+
+  const updateStem = (id, field, value) => {
+    setStem(stem.id === id ? { ...stem, [field]: value } : stem);
+  }
+
+  const updateFrame = (id, field, value) => {
+    setFrame(frame.id === id ? { ...frame, [field]: value } : frame);
+  }
+
+  useEffect(() => {
+    console.log(stem);  // This will log the updated state after it changes.
+    console.log(frame)
+  }, [stem, frame]);
   return (
     <div class="app-wrapper">
+      <ControlPanel stem={stem} frame={frame} stemChangeHandler={updateStem} frameChangeHandler={updateFrame} />
       <div class="workspace-wrapper">
         <Workspace gridSize={GRID_SIZE} pixelsPerMm={3} />
 

--- a/src-new/client/components/Controlpanel.tsx
+++ b/src-new/client/components/Controlpanel.tsx
@@ -1,0 +1,64 @@
+import { FunctionComponent } from 'preact';
+import { useEffect } from 'preact/hooks';
+
+import TextInput from './inputs/TextInput';
+
+const ControlPanel: FunctionComponent = ({
+  stem,
+  frame,
+  stemChangeHandler,
+  frameChangeHandler
+}) => {
+
+  return (
+    <div>
+      <div class="stem-metrics">
+        <h4>Bicycle Metrics</h4>
+        <TextInput 
+          name='Headtube Angle'
+          value='73'
+          type='number'
+          step='0.25'
+          min='65'
+          max='80'
+          onChange={(e) => frameChangeHandler(frame.id, 'headtubeAngle', Number(e.target.value))}
+        />
+      </div>
+      <div class="stem-metrics">
+        <h4>Stem Metrics</h4>
+        <TextInput 
+          name='Length (mm)'
+          value={stem.length}
+          type='number'
+          step='5'
+          min='20'
+          max='300'
+          onChange={(e) => stemChangeHandler(stem.id, 'length', Number(e.target.value))}
+        />
+
+        <TextInput 
+          name='Angle (degrees)'
+          value={stem.angle}
+          type='number'
+          step='1'
+          min='-80'
+          max='80'
+          onChange={(e) => stemChangeHandler(stem.id, 'angle', Number(e.target.value))}
+        />
+
+        <TextInput 
+          name='Stack Height (mm)'
+          value={stem.stackHeight}
+          type='number'
+          step='1'
+          min='0'
+          max='50'
+          onChange={(e) => stemChangeHandler(stem.id, 'stackHeight', Number(e.target.value))}
+        />
+      </div>
+      
+    </div>
+  )
+}
+
+export default ControlPanel;

--- a/src-new/client/components/Workspace.tsx
+++ b/src-new/client/components/Workspace.tsx
@@ -1,0 +1,48 @@
+import { FunctionComponent } from 'preact';
+import { useEffect } from 'preact/hooks';
+import { convertMmToPixels } from '../utils/mathUtils';
+
+const Workspace: FunctionComponent = ({
+  gridSize,
+  pixelsPerMm
+}) => {
+
+  console.log(gridSize)
+  const drawGridLines = (size: number) => {
+    const gridLines: SVGLineElement[] = [];
+    const gridStep = 10;
+    const gridCenter = gridSize / 2;
+    console.log(gridCenter)
+    for (let i = -gridCenter; i <= gridCenter; i += convertMmToPixels(gridStep, pixelsPerMm)) {
+      
+      //Generate a new line element, and push it to gridLines Array
+      gridLines.push(
+        <line
+          className={i === 0 ? 'grid-center-line' : 'grid-line'}
+          key={`vertical-axis-${i}`}
+          x1={gridCenter + i}
+          y1={0}
+          x2={gridCenter + i}
+          y2={gridSize}
+        />,
+        <line
+          className={i === 0 ? 'grid-center-line' : 'grid-line'}
+          key={`horizontal-axis-${i}`}
+          x1={0}
+          y1={gridCenter + i}
+          x2={gridSize}
+          y2={gridCenter + i}
+        />
+      );
+    }
+    return gridLines;
+  };
+
+  return (
+    <svg class="workspace cartesian-svg" width={gridSize} height={gridSize}>
+      {drawGridLines(gridSize)}
+    </svg>
+  )
+}
+
+export default Workspace;

--- a/src-new/client/components/inputs/TextInput.tsx
+++ b/src-new/client/components/inputs/TextInput.tsx
@@ -1,0 +1,29 @@
+import { FunctionComponent } from 'preact';
+
+const TextInput: FunctionComponent = ({
+  name,
+  value,
+  type,
+  step,
+  min,
+  max,
+  onChange
+}) => {
+
+  return (
+    <div class="cp-input">
+      <label for={name} className="cp-label">{name}</label>
+      <input
+        type={type}
+        value={value}
+        name={name}
+        step={step}
+        min={min}
+        max={max}
+        onChange={onChange}
+      />
+    </div>
+  )
+}
+
+export default TextInput;

--- a/src-new/client/main.tsx
+++ b/src-new/client/main.tsx
@@ -1,0 +1,9 @@
+import { render } from 'preact'
+import App from './app.tsx'
+import './index.css'
+
+
+(async () => {
+  const root = document.getElementById('app');
+  render(<App />, root)
+})();

--- a/src-new/client/utils/mathUtils.tsx
+++ b/src-new/client/utils/mathUtils.tsx
@@ -1,0 +1,6 @@
+/**
+ * Converts a mm value into pixels, to help approximate sizes on screen
+ * @param mm - Number - the mm number to convert
+ * @returns approximate px value
+ */
+export const convertMmToPixels = (mm: number, ratio: number) => mm * ratio;

--- a/src-new/client/vite-env.d.ts
+++ b/src-new/client/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "useDefineForClassFields": true,
     "module": "ESNext",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2020", "DOM", "dom", "DOM.Iterable"],
     "skipLibCheck": true,
     "paths": {
       "react": ["./node_modules/preact/compat/"],


### PR DESCRIPTION
Adds in a basic control panel that can be used to adjust the various angles of both a frame and stem object. These updates are stored in the state obj on change, and will be used to set specific values to the stem after it's drawn on the grid.

Frame obj:
- HT Angle (angle of head tube (degs))

Stem obj
- length (length of stem body (mm))
- angle (angle of stem (degs))
- stackHeight (height of stem (mm))