### PR TITLE
adds comparison feature for comparing multiple stems

### DIFF
--- a/src/client/app.css
+++ b/src/client/app.css
@@ -1,3 +1,8 @@
+.app-wrapper {
+  max-width: 900px;
+  margin:0 auto;
+  display: block;
+}
 .cartesian-svg line.grid-line {
   stroke: #ddd;
   stroke-width: 1;
@@ -10,4 +15,55 @@
 
 .debug {
   display: none
+}
+
+.multi-stem {
+  opacity: 75%;
+}
+
+.control-panel-wrapper {
+  display: flex;
+  gap: 1rem;
+}
+
+.control-panel {
+  border: 1px solid #000;
+  padding: 0rem 1rem 1rem;
+  margin: 1rem 0;
+}
+
+.control-panel.theme-red {
+  border:1px solid #FF0000;
+}
+
+.control-panel.theme-red h3{
+  color:#FF0000
+}
+
+.control-panel.theme-blue {
+  border:1px solid #0000FF;
+}
+
+.control-panel.theme-blue h3{
+  color:#0000FF;
+}
+
+.control-panel.theme-green {
+  border:1px solid #006401;
+}
+
+.control-panel.theme-green h3{
+  color:#006401;
+}
+
+.fragment-image.theme-green {
+  filter: invert(25%) sepia(98%) saturate(1680%) hue-rotate(106deg) brightness(94%) contrast(101%);
+}
+
+.fragment-image.theme-red {
+  filter: invert(27%) sepia(51%) saturate(2878%) hue-rotate(346deg) brightness(104%) contrast(97%); /* Red */
+}
+
+.fragment-image.theme-blue {
+  filter: invert(8%) sepia(98%) saturate(7458%) hue-rotate(248deg) brightness(97%) contrast(143%); /* Blue */
 }

--- a/src/client/app.tsx
+++ b/src/client/app.tsx
@@ -4,6 +4,7 @@ import './app.css';
 import { createStateUpdater } from './utils/state';
 import Workspace from './components/Workspace/Workspace'
 import { FrameStateObjProps, StemStateObjProps } from '../types';
+import { createNewStem, updateStemColors } from './utils/drawings';
 
 const App = () => {
   // Grid Information
@@ -16,26 +17,29 @@ const App = () => {
     headtubeAngle: 73,
   });
 
-  const [stem, setStem] = useState<StemStateObjProps>({
-    id: 'stem-1',
-    length: 100,
-    angle: 6,
-    stackHeight: 0,
-  });
+  const [stems, setStems] = useState<StemStateObjProps[]>([]);
 
-  const updateStem = createStateUpdater(stem, setStem);
+  const updateStems = createStateUpdater(stems, setStems);
   const updateFrame = createStateUpdater(frame, setFrame);
 
   useEffect(() => {
-    console.log(stem);  // This will log the updated state after it changes.
-    console.log(frame)
-  }, [stem, frame]);
+    console.log(stems, stems.length);  // This will log the updated state after it changes.
+  }, [stems, frame]);
+
+  useEffect(() => {
+    console.log('hello')
+    if (stems.length === 0) {
+      createNewStem(stems, updateStems.updateObject);
+    } else {
+      updateStemColors(stems, updateStems.updateField);
+    }
+  }, [stems.length])
   return (
     <div class="app-wrapper">
       <Workspace
-        stem={stem}
+        stems={stems}
         frame={frame}
-        updateStem={updateStem}
+        updateStems={updateStems}
         updateFrame={updateFrame}
         gridSize={GRID_SIZE}
         gridCenter={GRID_CENTER}

--- a/src/client/components/Accessories/SpacerStack.tsx
+++ b/src/client/components/Accessories/SpacerStack.tsx
@@ -9,6 +9,7 @@ const SpacerStack: FunctionComponent<SpacerProps> = ({
   y,
   width,
   rotation,
+  theme = 'theme-default',
 }) => {
   const spacers = drawSpacersOnScreen(totalHeight);
   let currentYAxis = y;
@@ -24,6 +25,7 @@ const SpacerStack: FunctionComponent<SpacerProps> = ({
             y={currentYAxis}
             width={width}
             rotation={rotation}
+            theme={theme}
           />
         );
         currentYAxis += spacerHeight;

--- a/src/client/components/Accessories/SpacerTypes.ts
+++ b/src/client/components/Accessories/SpacerTypes.ts
@@ -5,4 +5,5 @@ export interface SpacerProps {
   y: number;
   width: number;
   rotation: number;
+  theme: string;
 }

--- a/src/client/components/Stem/MergedStemFragments.tsx
+++ b/src/client/components/Stem/MergedStemFragments.tsx
@@ -8,7 +8,8 @@ const MergedStemFragments: FunctionComponent<MergedFragmentsProps> = ({
   config,
   fragment1,
   fragment2,
-  stem
+  stem,
+  theme
 }) => {
   const { 
     position: position1, 
@@ -70,6 +71,7 @@ const MergedStemFragments: FunctionComponent<MergedFragmentsProps> = ({
         floorPoint1={floor1}
         config={config}
         stem={stem}
+        theme={theme}
       />
 
       {/* Render Stem Face */}
@@ -85,26 +87,27 @@ const MergedStemFragments: FunctionComponent<MergedFragmentsProps> = ({
         additionalTransformation={additionalTransformation}
         config={config}
         stem={stem}
+        theme={theme}
       /> 
 
       {/* Render Body Lines using transformed coordinates */}
       <path
       d={drawBezierCurveConnection(point1, transformedPoint2, stem.angle)}
-      stroke="#FF0000"
+      stroke={stem.color}
       strokeWidth={1 * scale1}
       fill="none"
       className="connection-line"
     />
     <path
       d={drawBezierCurveConnection(point1B, transformedPoint2B, stem.angle)}
-      stroke="#FF0000"
+      stroke={stem.color}
       strokeWidth={1 * scale1}
       fill="none"
       className="connection-line"
     />
     <path
       d={drawBezierCurveConnection(pointFloor1, transformedPointFloor, stem.angle)}
-      stroke="#FF0000"
+      stroke={stem.color}
       strokeWidth={1 * scale1}
       fill="none"
       className="connection-line debug"

--- a/src/client/components/Stem/Stem.tsx
+++ b/src/client/components/Stem/Stem.tsx
@@ -4,12 +4,15 @@ import { StemComponentProps } from './StemTypes';
 import MergedStemFragments from './MergedStemFragments';
 
 const Stem: FunctionComponent<StemComponentProps> = ({
+  key,
+  className,
   stem,
   frame,
   config,
   gridSize,
   gridCenter,
-  gridRatio
+  gridRatio,
+  theme,
 }) => {
   const stemCoords = calculateStemCoords(stem, gridCenter);
   // Stem does not offset vertically with stack change
@@ -20,7 +23,7 @@ const Stem: FunctionComponent<StemComponentProps> = ({
   const faceTransformation = `rotate(${-stem.angle} ${stemCoords.face.center.x} ${stemCoords.face.center.y})`;
 
   return (
-    <g transform={mainTransformation}>
+    <g transform={mainTransformation} key={`newStem-${key}`} className={className}>
       {/* Reference line */}
       <line
         x1={stemCoords.collar.center.x}
@@ -33,8 +36,10 @@ const Stem: FunctionComponent<StemComponentProps> = ({
       />
 
       <MergedStemFragments
+        className={className}
         config={config}
         stem={stem}
+        theme={theme}
         fragment1={{
           position: 'collar',
           x: stemCoords.collar.center.x,
@@ -46,6 +51,7 @@ const Stem: FunctionComponent<StemComponentProps> = ({
           floorPoint1: config.diagrams.collar.connections.floor,
           config: config,
           stem: stem,
+          theme: theme,
         }}
         fragment2={{
           position: 'face',
@@ -59,6 +65,7 @@ const Stem: FunctionComponent<StemComponentProps> = ({
           floorPoint1: config.diagrams.face.connections.floor,
           config: config,
           stem: stem,
+          theme: theme,
         }}
       />
     </g>

--- a/src/client/components/Stem/StemFragment.tsx
+++ b/src/client/components/Stem/StemFragment.tsx
@@ -4,6 +4,7 @@ import { StemFragmentProps } from './StemTypes';
 import SpacerStack from '../Accessories/SpacerStack';
 
 const StemFragment: FunctionComponent<StemFragmentProps> = ({
+  theme,
   position,
   x,
   y,
@@ -14,9 +15,8 @@ const StemFragment: FunctionComponent<StemFragmentProps> = ({
   floorPoint1,
   additionalTransformation = '',
   config,
-  stem
+  stem,
 }) => {
-  console.log(config, stem)
   const svgWidth = position === 'collar' ? config.collarLength : config.faceLength;
   const svgHeight = config.exactHeight;
   const width = svgWidth * scale;
@@ -46,7 +46,7 @@ const StemFragment: FunctionComponent<StemFragmentProps> = ({
           href={position === 'collar' ? config.diagrams.collar.path : config.diagrams.face.path}
           width={width}
           height={height}
-          className="fragment-image"
+          className={`fragment-image ${theme}`}
         />
 
         {/* Add spacers only for collar fragment */}
@@ -57,6 +57,7 @@ const StemFragment: FunctionComponent<StemFragmentProps> = ({
             y={height / 2 + bottomPoint}
             width={spacerWidth}
             rotation={0}
+            theme={theme}
           />
         )}
       </g>

--- a/src/client/components/Stem/StemTypes.ts
+++ b/src/client/components/Stem/StemTypes.ts
@@ -16,20 +16,24 @@ export interface StemFragmentProps {
   additionalTransformation?: string;
   config: StemConfigProps;
   stem: StemStateObjProps;
+  theme: string;
 }
 
 export interface MergedFragmentsProps {
   config: StemConfigProps;
   stem: StemStateObjProps;
+  theme: string;
   fragment1: StemFragmentProps;
   fragment2: StemFragmentProps;
 }
 
 export interface StemComponentProps {
+  className: string;
   stem: StemStateObjProps;
   frame: FrameStateObjProps;
   config: StemConfigProps;
   gridSize: number;
   gridCenter: number;
   gridRatio: number;
+  theme: string;
 }

--- a/src/client/components/Workspace/CartesianGrid.tsx
+++ b/src/client/components/Workspace/CartesianGrid.tsx
@@ -8,21 +8,34 @@ const CartesianGrid: FunctionComponent<GridProps> = ({
   gridRatio,
   gridStep = 10
 }) => {
+  // Set the origin point to be 1/4 of the grid width from the left
+  const originX = gridSize / 4;
   const gridElements = [];
   
-  for (let i = -gridCenter; i <= gridCenter; i += convertMmToPixels(gridStep, gridRatio)) {
-    // Grid lines
+  // Calculate the number of steps needed on each side of the origin
+  const stepsToRight = Math.floor((gridSize - originX) / convertMmToPixels(gridStep, gridRatio));
+  const stepsToLeft = Math.floor(originX / convertMmToPixels(gridStep, gridRatio));
+  
+  // Draw vertical lines
+  for (let i = -stepsToLeft; i <= stepsToRight; i++) {
+    const x = originX + (i * convertMmToPixels(gridStep, gridRatio));
     gridElements.push(
       <line
         className={i === 0 ? 'grid-center-line' : 'grid-line'}
         key={`vertical-axis-${i}`}
-        x1={gridCenter + i}
+        x1={x}
         y1={0}
-        x2={gridCenter + i}
+        x2={x}
         y2={gridSize}
         stroke="#ccc"
         strokeWidth={i === 0 ? 2 : 1}
-      />,
+      />
+    );
+  }
+
+  // Draw horizontal lines
+  for (let i = -gridCenter; i <= gridCenter; i += convertMmToPixels(gridStep, gridRatio)) {
+    gridElements.push(
       <line
         className={i === 0 ? 'grid-center-line' : 'grid-line'}
         key={`horizontal-axis-${i}`}
@@ -35,6 +48,7 @@ const CartesianGrid: FunctionComponent<GridProps> = ({
       />
     );
   }
+
   return (
     <svg 
       width={gridSize} 

--- a/src/client/components/Workspace/Controlpanel.tsx
+++ b/src/client/components/Workspace/Controlpanel.tsx
@@ -1,16 +1,21 @@
 import { FunctionComponent, JSX } from 'preact';
 import { ControlPanelProps } from './WorkspaceTypes';
 import TextInput from '../inputs/TextInput';
+import { StemStateObjProps } from '../../../types';
+import { createNewStem,removeExistingStem, getStemTheme } from '../../utils/drawings';
+import Button from '../inputs/Button';
 
 const ControlPanel: FunctionComponent<ControlPanelProps> = ({
-  stem,
+  stems,
   frame,
-  updateStem,
+  updateStems,
   updateFrame,
 }) => {
+  const totalStems = stems.length;
+
   return (
-    <div>
-      <div class="stem-metrics">
+    <div class="control-panel-wrapper">
+      <div class="frame-metrics control-panel">
         <h4>Frame Metrics</h4>
         <TextInput 
           name='Headtube Angle'
@@ -20,48 +25,66 @@ const ControlPanel: FunctionComponent<ControlPanelProps> = ({
           min={65}
           max={80}
           onChange={(e: JSX.TargetedEvent<HTMLInputElement>) => 
-            updateFrame(frame.id, 'headtubeAngle', Number(e.currentTarget.value))
-          }
-        />
-      </div>
-      <div class="stem-metrics">
-        <h4>Stem Metrics</h4>
-        <TextInput 
-          name='Length (mm)'
-          value={stem.length}
-          type='number'
-          step={5}
-          min={20}
-          max={300}
-          onChange={(e: JSX.TargetedEvent<HTMLInputElement>) => 
-            updateStem(stem.id, 'length', Number(e.currentTarget.value))
+            updateFrame.updateField(frame.id, 'headtubeAngle', Number(e.currentTarget.value))
           }
         />
 
-        <TextInput 
-          name='Angle (degrees)'
-          value={stem.angle}
-          type='number'
-          step={1}
-          min={-35}
-          max={35}
-          onChange={(e: JSX.TargetedEvent<HTMLInputElement>) => 
-            updateStem(stem.id, 'angle', Number(e.currentTarget.value))
-          }
-        />
-
-        <TextInput 
-          name='Stack Height (mm)'
-          value={stem.stackHeight}
-          type='number'
-          step={1}
-          min={0}
-          max={50}
-          onChange={(e: JSX.TargetedEvent<HTMLInputElement>) => 
-            updateStem(stem.id, 'stackHeight', Number(e.currentTarget.value))
-          }
+        <Button
+          name='New Stem'
+          value='New Stem'
+          disabled={stems.length >= 3}
+          onClick={(e) => {createNewStem(stems, updateStems.updateObject)}}
         />
       </div>
+      {stems.map((stem: StemStateObjProps, index: number) => (
+        <div class={`stem-metrics multistem-${index} control-panel ${getStemTheme(totalStems, index)}`} key={stem.id}>
+          <h3>Stem {index+1} Metrics</h3>
+          <TextInput 
+            name='Length (mm)'
+            value={stem.length}
+            type='number'
+            step={5}
+            min={20}
+            max={300}
+            onChange={(e: JSX.TargetedEvent<HTMLInputElement>) => 
+              updateStems.updateField(stem.id, 'length', Number(e.currentTarget.value))
+            }
+          />
+
+          <TextInput 
+            name='Angle (degrees)'
+            value={stem.angle}
+            type='number'
+            step={1}
+            min={-35}
+            max={35}
+            onChange={(e: JSX.TargetedEvent<HTMLInputElement>) => 
+              updateStems.updateField(stem.id, 'angle', Number(e.currentTarget.value))
+            }
+          />
+
+          <TextInput 
+            name='Stack Height (mm)'
+            value={stem.stackHeight}
+            type='number'
+            step={1}
+            min={0}
+            max={50}
+            onChange={(e: JSX.TargetedEvent<HTMLInputElement>) => 
+              updateStems.updateField(stem.id, 'stackHeight', Number(e.currentTarget.value))
+            }
+          />
+
+          {totalStems > 1 &&
+            <Button
+              name='Remove Stem'
+              value='Remove Stem'
+              disabled={false}
+              onClick={() => {removeExistingStem(stems[index].id, updateStems.removeObject)}}
+            />
+          }
+        </div>
+      ))}
       
     </div>
   )

--- a/src/client/components/Workspace/Workspace.tsx
+++ b/src/client/components/Workspace/Workspace.tsx
@@ -4,26 +4,28 @@ import ControlPanel from './Controlpanel';
 import CartesianGrid from './CartesianGrid';
 import Stem from '../Stem/Stem';
 import Thomson from '../../configs/thomson';
+import { StemStateObjProps } from '../../../types';
+import { getStemTheme } from '../../utils/drawings';
 
 const Workspace: FunctionComponent<WorkspaceProps> = ({
-  stem,
-  updateStem,
+  stems,
+  updateStems,
   frame,
   updateFrame,
   gridSize,
   gridCenter,
   gridRatio,
 }) => {
-  console.log(Thomson)
+  const totalStems = stems.length;
+
   return (
   <div>
-
-    <ControlPanel 
-      stem={stem}
-      frame={frame}
-      updateStem={updateStem}
-      updateFrame={updateFrame}
-    />
+      <ControlPanel
+        stems={stems}
+        frame={frame}
+        updateStems={updateStems}
+        updateFrame={updateFrame}
+      />
 
     <svg width={gridSize} height={gridSize} className='cartesian-svg'>
       <CartesianGrid 
@@ -32,15 +34,20 @@ const Workspace: FunctionComponent<WorkspaceProps> = ({
         gridRatio={gridRatio} 
       />
       
-      <Stem
-        key={stem.id}
-        stem={stem}
-        frame={frame}
-        config={Thomson}
-        gridSize={gridSize}
-        gridCenter={gridCenter}
-        gridRatio={gridRatio}
-      />
+      {stems.map((stem: StemStateObjProps, index: number) => (
+        <Stem
+          className={stems.length > 1 ? 'multi-stem' : ''}
+          key={index}
+          stem={stem}
+          theme={getStemTheme(totalStems, index)}
+          frame={frame}
+          config={Thomson}
+          gridSize={gridSize}
+          gridCenter={gridCenter}
+          gridRatio={gridRatio}
+        />
+      ))}
+
     </svg>   
   </div>
 )

--- a/src/client/components/Workspace/WorkspaceTypes.ts
+++ b/src/client/components/Workspace/WorkspaceTypes.ts
@@ -13,13 +13,13 @@ export interface WorkspaceProps {
   gridSize: number;
   gridCenter: number;
   gridRatio: number;
-  updateStem: UpdateFunction<StemStateObjProps>;
+  updateStems: UpdateFunction<StemStateObjProps>;
   updateFrame: UpdateFunction<FrameStateObjProps>;
 }
 
 export interface ControlPanelProps {
-  stem: StemStateObjProps;
+  stems: StemStateObjProps[];
   frame: FrameStateObjProps;
-  updateStem: UpdateFunction<StemStateObjProps>;
+  updateStems: UpdateFunction<StemStateObjProps>;
   updateFrame: UpdateFunction<FrameStateObjProps>;
 }

--- a/src/client/components/inputs/Button.tsx
+++ b/src/client/components/inputs/Button.tsx
@@ -1,0 +1,20 @@
+import { FunctionComponent } from 'preact';
+import { ButtonInputProps } from './InputTypes';
+
+const Button: FunctionComponent<ButtonInputProps> = ({
+  name,
+  value,
+  disabled,
+  onClick,
+}) => {
+
+  return (
+    <div class="button">
+      <button disabled={disabled} onClick={onClick}>
+        {value}
+      </button>
+    </div>
+  )
+}
+
+export default Button;

--- a/src/client/components/inputs/InputTypes.ts
+++ b/src/client/components/inputs/InputTypes.ts
@@ -9,3 +9,10 @@ export interface TextInputProps {
   max: number;
   onChange: (e: JSX.TargetedEvent<HTMLInputElement, Event>) => void;
 }
+
+export interface ButtonInputProps {
+  name: string;
+  value: string | number;
+  disabled: boolean;
+  onClick: (e: JSX.TargetedEvent<HTMLInputElement, Event>) => void;
+}

--- a/src/client/configs/defaults.ts
+++ b/src/client/configs/defaults.ts
@@ -1,0 +1,14 @@
+import { StemStateObjProps } from "../../types";
+
+export const StemColors = {
+  single: '#000000',
+  multiple: ['#ff0000', '#0000ff', '#006401'],
+};
+
+export const NewStem: StemStateObjProps = {
+  angle: 0,
+  id: 'stem-0',
+  length: 100,
+  stackHeight: 0,
+  color: '#000000',
+}

--- a/src/client/utils/calculations.tsx
+++ b/src/client/utils/calculations.tsx
@@ -73,9 +73,12 @@ export const calculateStemCoords = (
   const stemAngleInRadians = (stem.angle * Math.PI) / 180;
   const stemStack = Math.sin(stemAngleInRadians) * stem.length;
   const stemHeight = convertMmToPixels(10);
+  
+  // Position the collar point at 1/4 of the grid width instead of center
+  const originX = gridCenter / 2;  // This puts the origin at 1/4 of the grid width
 
   const stemCollarCenterLine = {
-    x: gridCenter - convertMmToPixels(stem.length)/2,
+    x: originX,
     y: gridCenter
   }
 

--- a/src/client/utils/drawings.tsx
+++ b/src/client/utils/drawings.tsx
@@ -1,4 +1,5 @@
-import { XYCoordinateProps } from '../../types';
+import { UpdateObjectFunction, UpdateFieldFunction, StemStateObjProps, XYCoordinateProps } from '../../types';
+import { NewStem, StemColors } from '../configs/defaults';
 import { getSpacersForSize } from './calculations';
 
 /**
@@ -86,4 +87,61 @@ export const drawBezierCurveConnection = (start: XYCoordinateProps, end: XYCoord
   };
   
   return `M ${start.x},${start.y} C ${cp1.x},${cp1.y} ${cp2.x},${cp2.y} ${end.x},${end.y}`;
+};
+
+/**
+ * Function for initializing a new stem from the config template
+ * @param stems - StemStateObjProps[] - the current stems in the State
+ * @param updateObject - UpdaterFunction - Add a new object to the Stems array
+ */
+export const createNewStem = (
+  stems: StemStateObjProps[],
+  updateObject: UpdateObjectFunction<StemStateObjProps>,
+) => {
+  const newStem = {
+    ...NewStem,
+    id: `stem-${stems.length}`,
+    color: stems.length === 0 ? StemColors.single : StemColors.multiple[stems.length],
+  }
+  updateObject(newStem);
+}
+
+export const removeExistingStem = (
+  stemId: string,
+  removeObject: (id: string | number) => void
+) => removeObject(stemId);
+
+/**
+ * Updates the perceived line-work color for the drawn stems based on the number
+ * of Stems drawn to the workspace
+ * 1 stem - black linework
+ * 2 stems - 1 red, 1 blue linework
+ * 3 stems - 1 red, 1 blue, 1 green linework
+ * @param stems - StemStateObjProps[] - the current stems in the State
+ * @param updateField - UpdaterFunction - Using the stem's id, update an individual field
+ */
+export const updateStemColors = (
+  stems: StemStateObjProps[],
+  updateField: UpdateFieldFunction<StemStateObjProps>,
+) => {
+  if (!stems.length) return;
+
+  if (stems.length === 1) {
+    updateField(stems[0].id, 'color', StemColors.single);
+  } else {
+    stems.forEach((stem, index) => {
+      const predictedColor = StemColors.multiple[index];
+      if (stem.color !== predictedColor) updateField(stem.id, 'color', predictedColor);
+    });
+  }
+}
+
+export const getStemTheme = (totalStems: number, index: number): string => {
+  const themeMap: Record<number, string> = {
+    0: 'theme-red',
+    1: 'theme-blue',
+    2: 'theme-green'
+  };
+
+  return totalStems > 1 ? themeMap[index] : 'theme-default';
 };

--- a/src/client/utils/state.tsx
+++ b/src/client/utils/state.tsx
@@ -1,13 +1,38 @@
-import { HasId } from '../../types';
+import { HasId, StateUpdater } from '../../types';
 
-/**
- * Updates the state values of current objects on the workspace (Stem / Frame)
- * @param state - Object to update
- * @param setState - State updating function
- * @returns Emits an update to the selected state obejct
- */
 export const createStateUpdater = <T extends HasId>(
-  state: T,
-  setState: (value: T) => void
-) => (id: T['id'], field: keyof T, value: T[keyof T]) =>
-  setState(state.id === id ? { ...state, [field]: value } : state);
+  state: T | T[],
+  setState: (value: T | T[]) => void
+): StateUpdater<T> => {
+  return {
+    updateField: (id, field, value) => {
+      if (Array.isArray(state)) {
+        setState(
+          state.map((item) =>
+            item.id === id ? { ...item, [field]: value } : item
+          )
+        );
+      } else {
+        setState(state.id === id ? { ...state, [field]: value } : state);
+      }
+    },
+    updateObject: (newObject) => {
+      if (Array.isArray(state)) {
+        setState([...state, newObject]);
+      } else {
+        setState(state.id === newObject.id ? newObject : state);
+      }
+    },
+    removeObject: (id) => {
+      if (Array.isArray(state)) {
+        const filteredStems = state.filter(item => item.id !== id);        
+        const reindexedStems = filteredStems.map((stem, index) => ({
+          ...stem,
+          id: `stem-${index}`
+        }));
+
+        setState(reindexedStems);
+      }
+    }
+  };
+};

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -18,6 +18,7 @@ export interface StemStateObjProps {
   id: string;
   length: number;
   stackHeight: number;
+  color: string;
 }
 
 export interface FrameStateObjProps {

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -1,5 +1,3 @@
-export type HasId = { id: string | number };
-
 export interface XYCoordinateProps {
   x: number;
   y: number;
@@ -11,8 +9,28 @@ export interface TransformationProps {
   centerY: number;
 }
 
-export type UpdateFunction <T extends { id: string | number }> = <K extends keyof T>(
-  id: string,
+/**
+ * Updates the state values of current objects on the workspace (Stem / Frame)
+ * @param state - Object to update
+ * @param setState - State updating function
+ * @returns Emits an update to the selected state obejct
+ */
+export interface HasId {
+  id: string | number;
+}
+
+export type UpdateFieldFunction<T extends HasId> = <K extends keyof T>(
+  id: T['id'],
   field: K,
   value: T[K]
 ) => void;
+
+export type UpdateObjectFunction<T extends HasId> = (
+  newObject: T
+) => void;
+
+export type StateUpdater<T extends HasId> = {
+  updateField: UpdateFieldFunction<T>;
+  updateObject: UpdateObjectFunction<T>;
+  removeObject: (id: string | number) => void;
+};


### PR DESCRIPTION
Adds in controls to handle multiple stem-comparisons at a given time. The new panels allow you to add up to 3 stems, and will color code them accordingly. The newly generated stems are new components, and have their data separated allowing for their data to be modified separately.

This means you can move them completely independently, and the data that is stored (not yet printed to screen) will be used for quick comparison equations.
![Screen Shot 2025-01-22 at 1 21 25 AM](https://github.com/user-attachments/assets/4e137ca4-53d7-45df-bbda-cafaff4957fa)

Removing a stem will completely remove it from state, and readjust the stem's state IDs so you don't end up overwriting existing stems.

Additionally:
- Adds light theming of RGB to handle the differences
- Adds an UpdateObject, UpdateField and RemoveObject method to the state updaters
- Moves the Y axis further to the left so the stem is more left aligned on load (this is to avoid it moving on the x-axis while adjusting length)
- 