### PR TITLE
add multi-frame toggling, fix stem spacer stacking

### DIFF
--- a/src/client/app.css
+++ b/src/client/app.css
@@ -21,38 +21,73 @@
   opacity: 75%;
 }
 
-.control-panel-wrapper {
-  display: flex;
-  gap: 1rem;
+.workspace-panel {
+  border: 1px solid #000;
+  padding: 0rem 1rem 1rem;
 }
 
 .control-panel {
-  border: 1px solid #000;
-  padding: 0rem 1rem 1rem;
+  border-top: 1px solid #000;
+  padding-top: 1rem;;
+  display: flex;
   margin: 1rem 0;
 }
 
-.control-panel.theme-red {
-  border:1px solid #FF0000;
+.control-panel.control-buttons {
+  justify-content: end;
 }
 
-.control-panel.theme-red h3{
+.control-panel button {
+  margin: 0 0.5rem;
+}
+
+.frame-metrics, .stem-metrics {
+  display: flex;
+}
+.stem-metrics {
+  flex: 1;
+}
+
+.multiframe {
+  flex-direction: row;
+  padding: 0 1rem;
+}
+
+.multistem { 
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  border-left: 1px solid #000;
+  padding: 0 1rem;
+  border-top:5px solid #000;
+}
+
+.frame-metrics {
+  flex-direction: column;
+  border-top:5px solid #000;
+}
+
+.multistem.theme-red {
+  border-top:5px solid #FF0000;
+}
+
+.multistem.theme-red h3{
   color:#FF0000
 }
 
-.control-panel.theme-blue {
-  border:1px solid #0000FF;
+.multistem.theme-blue {
+  border-top:5px solid #0000FF;
 }
 
-.control-panel.theme-blue h3{
+.multistem.theme-blue h3{
   color:#0000FF;
 }
 
-.control-panel.theme-green {
-  border:1px solid #006401;
+.multistem.theme-green {
+  border-top:5px solid #006401;
 }
 
-.control-panel.theme-green h3{
+.multistem..theme-green h3{
   color:#006401;
 }
 
@@ -66,4 +101,18 @@
 
 .fragment-image.theme-blue {
   filter: invert(8%) sepia(98%) saturate(7458%) hue-rotate(248deg) brightness(97%) contrast(143%); /* Blue */
+}
+
+.cp-input {
+  display: flex;
+  flex-direction: column;
+  margin: 0.5rem 0;;
+}
+
+.cp-input input {
+  width: 100%;
+  padding: 4px 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  max-width: 80%;
 }

--- a/src/client/app.css
+++ b/src/client/app.css
@@ -87,7 +87,7 @@
   border-top:5px solid #006401;
 }
 
-.multistem..theme-green h3{
+.multistem.theme-green h3{
   color:#006401;
 }
 

--- a/src/client/app.tsx
+++ b/src/client/app.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'preact/hooks'
 import './app.css';
 
-import { createStateUpdater } from './utils/state';
+import { createStateUpdater, toggleActiveState } from './utils/state';
 import Workspace from './components/Workspace/Workspace'
 import { FrameStateObjProps, StemStateObjProps } from '../types';
-import { createNewStem, updateStemColors } from './utils/drawings';
+import { initializeNewElement, updateStemColors } from './utils/drawings';
 
 const App = () => {
   // Grid Information
@@ -12,35 +12,45 @@ const App = () => {
   const GRID_SIZE = 600;
   const GRID_CENTER = GRID_SIZE / 2;
 
-  const [frame, setFrame] = useState<FrameStateObjProps>({
-    id: 'frame-1',
-    headtubeAngle: 73,
-  });
-
+  const [frames, setFrames] = useState<FrameStateObjProps[]>([]);
   const [stems, setStems] = useState<StemStateObjProps[]>([]);
+  const [clickedElementId, setClickedElementId] = useState<string | null>(null);
 
   const updateStems = createStateUpdater(stems, setStems);
-  const updateFrame = createStateUpdater(frame, setFrame);
+  const updateFrames = createStateUpdater(frames, setFrames);
 
   useEffect(() => {
-    console.log(stems, stems.length);  // This will log the updated state after it changes.
-  }, [stems, frame]);
+    console.log(clickedElementId, frames)
+
+  }, [stems, frames]);
 
   useEffect(() => {
-    console.log('hello')
     if (stems.length === 0) {
-      createNewStem(stems, updateStems.updateObject);
+      initializeNewElement('frame', frames, updateFrames.updateObject)
+      initializeNewElement('stem', stems, updateStems.updateObject);
+
     } else {
       updateStemColors(stems, updateStems.updateField);
     }
   }, [stems.length])
+
+  useEffect(() => {
+    if (clickedElementId) {
+      toggleActiveState(frames, clickedElementId, setFrames);
+    }
+
+  }, [clickedElementId]);
+  
+  
+
   return (
     <div class="app-wrapper">
       <Workspace
         stems={stems}
-        frame={frame}
+        frames={frames}
         updateStems={updateStems}
-        updateFrame={updateFrame}
+        updateFrames={updateFrames}
+        setClickedElementId={setClickedElementId}
         gridSize={GRID_SIZE}
         gridCenter={GRID_CENTER}
         gridRatio={PIXELS_PER_MM}

--- a/src/client/components/Accessories/Spacer.tsx
+++ b/src/client/components/Accessories/Spacer.tsx
@@ -7,16 +7,18 @@ const Spacer: FunctionComponent<SpacerProps> = ({
   y,
   width,
   rotation,
+  theme,
+  stemColor
 }) => {
   return (
     <rect
-      className='stem-spacer'
+      className={`stem-spacer ${theme}`}
       x={x - width / 2}
       y={y}
       width={width}
       height={height}
-      fill='#cccccc'
-      stroke='#999999'
+      fill='transparent'
+      stroke={stemColor}
       strokeWidth={1}
       transform={`rotate(${rotation} ${x} ${y})`}
     />

--- a/src/client/components/Accessories/SpacerStack.tsx
+++ b/src/client/components/Accessories/SpacerStack.tsx
@@ -10,6 +10,7 @@ const SpacerStack: FunctionComponent<SpacerProps> = ({
   width,
   rotation,
   theme = 'theme-default',
+  stemColor,
 }) => {
   const spacers = drawSpacersOnScreen(totalHeight);
   let currentYAxis = y;
@@ -20,15 +21,16 @@ const SpacerStack: FunctionComponent<SpacerProps> = ({
         const spacer = (
           <Spacer
             key={index}
-            height={spacerHeight}
+            height={spacerHeight * 3}
             x={x}
             y={currentYAxis}
             width={width}
             rotation={rotation}
             theme={theme}
+            stemColor={stemColor}
           />
         );
-        currentYAxis += spacerHeight;
+        currentYAxis += spacerHeight * 3;
         return spacer;
       })}
     </g>

--- a/src/client/components/Accessories/SpacerTypes.ts
+++ b/src/client/components/Accessories/SpacerTypes.ts
@@ -6,4 +6,5 @@ export interface SpacerProps {
   width: number;
   rotation: number;
   theme: string;
+  stemColor: string;
 }

--- a/src/client/components/Stem/Stem.tsx
+++ b/src/client/components/Stem/Stem.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent } from 'preact';
-import { calculateStemCoords } from '../../utils/calculations';
+import { calculateStemCoords, calculateStackOffset } from '../../utils/calculations';
 import { StemComponentProps } from './StemTypes';
 import MergedStemFragments from './MergedStemFragments';
 
@@ -16,12 +16,12 @@ const Stem: FunctionComponent<StemComponentProps> = ({
 }) => {
   const stemCoords = calculateStemCoords(stem, gridCenter);
   // Stem does not offset vertically with stack change
-  const stemStackOffset = {x: 0, y: 0};
+  const stemStackOffset = calculateStackOffset(stem.stackHeight, frame.headtubeAngle);
 
   const mainTransformation = `translate(${stemStackOffset.x} ${stemStackOffset.y}) 
-    rotate(${frame.headtubeAngle - 90} ${stemCoords.collar.center.x} ${stemCoords.collar.center.y})`;
+                              rotate(${frame.headtubeAngle - 90} ${stemCoords.collar.center.x} ${stemCoords.collar.center.y})`;
+  
   const faceTransformation = `rotate(${-stem.angle} ${stemCoords.face.center.x} ${stemCoords.face.center.y})`;
-
   return (
     <g transform={mainTransformation} key={`newStem-${key}`} className={className}>
       {/* Reference line */}

--- a/src/client/components/Stem/StemFragment.tsx
+++ b/src/client/components/Stem/StemFragment.tsx
@@ -2,7 +2,21 @@ import { FunctionComponent } from 'preact';
 import { getRotatedPoint, parseTransformationCoords, applyTransformationCoords } from '../../utils/cartesianCoords';
 import { StemFragmentProps } from './StemTypes';
 import SpacerStack from '../Accessories/SpacerStack';
+import { convertMmToPixels } from '../../utils/calculations';
 
+
+/**
+ * IMPORTANT *
+ * 
+ * The stem's stack height is calculated by placing the expected spacers
+ * at the floor point of the stem collar. This results in a negative value.
+ *
+ * This utilized the cartesian grid at scale (at the time 10mm is 1 square), to
+ * try and maintain realistic sizing.
+ * 
+ * stem.stackHeight is the mm value passed to it via an input, it does not need converted
+ * in this rendering. And instead is handled when offset is calculated.
+ */
 const StemFragment: FunctionComponent<StemFragmentProps> = ({
   theme,
   position,
@@ -57,6 +71,7 @@ const StemFragment: FunctionComponent<StemFragmentProps> = ({
             y={height / 2 + bottomPoint}
             width={spacerWidth}
             rotation={0}
+            stemColor={stem.color}
             theme={theme}
           />
         )}

--- a/src/client/components/Workspace/Controlpanel.tsx
+++ b/src/client/components/Workspace/Controlpanel.tsx
@@ -1,91 +1,144 @@
 import { FunctionComponent, JSX } from 'preact';
 import { ControlPanelProps } from './WorkspaceTypes';
+import NumberInput from '../inputs/NumberInput';
 import TextInput from '../inputs/TextInput';
-import { StemStateObjProps } from '../../../types';
-import { createNewStem,removeExistingStem, getStemTheme } from '../../utils/drawings';
+import { StemStateObjProps, FrameStateObjProps } from '../../../types';
+import { initializeNewElement,removeExistingStem, getStemTheme, toggleFrameAngles } from '../../utils/drawings';
 import Button from '../inputs/Button';
 
 const ControlPanel: FunctionComponent<ControlPanelProps> = ({
   stems,
-  frame,
+  frames,
   updateStems,
-  updateFrame,
+  updateFrames,
+  setClickedElementId,
 }) => {
   const totalStems = stems.length;
 
   return (
     <div class="control-panel-wrapper">
-      <div class="frame-metrics control-panel">
-        <h4>Frame Metrics</h4>
-        <TextInput 
-          name='Headtube Angle'
-          value={frame.headtubeAngle}
-          type='number'
-          step={0.25}
-          min={65}
-          max={80}
-          onChange={(e: JSX.TargetedEvent<HTMLInputElement>) => 
-            updateFrame.updateField(frame.id, 'headtubeAngle', Number(e.currentTarget.value))
-          }
-        />
+        <p>Use the following controls to add new elements to the workspace. The workspace grid will update live as you adjust the angles and specs of your Stems and Frames.</p>
+        <p>Compare up to (3) stems, across (2) different framesets</p>
 
-        <Button
-          name='New Stem'
-          value='New Stem'
-          disabled={stems.length >= 3}
-          onClick={(e) => {createNewStem(stems, updateStems.updateObject)}}
-        />
-      </div>
-      {stems.map((stem: StemStateObjProps, index: number) => (
-        <div class={`stem-metrics multistem-${index} control-panel ${getStemTheme(totalStems, index)}`} key={stem.id}>
-          <h3>Stem {index+1} Metrics</h3>
-          <TextInput 
-            name='Length (mm)'
-            value={stem.length}
-            type='number'
-            step={5}
-            min={20}
-            max={300}
-            onChange={(e: JSX.TargetedEvent<HTMLInputElement>) => 
-              updateStems.updateField(stem.id, 'length', Number(e.currentTarget.value))
-            }
-          />
+        <div class="control-panel">
+          <div class="frame-metrics">
+            {frames.map((frame: FrameStateObjProps, index: number) => (
+              <div class="multiframe multiframe-${index}">
+                <h3>{frame.name ? frame.name : `Frameset ${index+1}`}</h3>
+                <TextInput 
+                  name='Frame Name'
+                  value={frame.name}
+                  type='string'
+                  onChange={(e: JSX.TargetedEvent<HTMLInputElement>) => 
+                    updateFrames.updateField(frame.id, 'name', e.currentTarget.value)
+                  }
+                />
 
-          <TextInput 
-            name='Angle (degrees)'
-            value={stem.angle}
-            type='number'
-            step={1}
-            min={-35}
-            max={35}
-            onChange={(e: JSX.TargetedEvent<HTMLInputElement>) => 
-              updateStems.updateField(stem.id, 'angle', Number(e.currentTarget.value))
-            }
-          />
+                <NumberInput 
+                  name='Headtube Angle'
+                  value={frame.headtubeAngle}
+                  type='number'
+                  step={0.25}
+                  min={65}
+                  max={80}
+                  onChange={(e: JSX.TargetedEvent<HTMLInputElement>) => 
+                    updateFrames.updateField(frame.id, 'headtubeAngle', Number(e.currentTarget.value))
+                  }
+                />
+              </div>
+            ))}
+          </div>
+          
+          <div class="stem-metrics">
+            {stems.map((stem: StemStateObjProps, index: number) => (
+              <div class={`multistem multistem-${index} ${getStemTheme(totalStems, index)}`} key={stem.id}>
+                <h3>{stem.name ? stem.name : `Stem ${index+1}`}</h3>
+                <TextInput 
+                  name='Stem Name'
+                  value={stem.name}
+                  type='string'
+                  onChange={(e: JSX.TargetedEvent<HTMLInputElement>) => 
+                    updateStems.updateField(stem.id, 'name', e.currentTarget.value)
+                  }
+                />
 
-          <TextInput 
-            name='Stack Height (mm)'
-            value={stem.stackHeight}
-            type='number'
-            step={1}
-            min={0}
-            max={50}
-            onChange={(e: JSX.TargetedEvent<HTMLInputElement>) => 
-              updateStems.updateField(stem.id, 'stackHeight', Number(e.currentTarget.value))
-            }
-          />
+                <NumberInput 
+                  name='Length (mm)'
+                  value={stem.length}
+                  type='number'
+                  step={5}
+                  min={20}
+                  max={300}
+                  onChange={(e: JSX.TargetedEvent<HTMLInputElement>) => 
+                    updateStems.updateField(stem.id, 'length', Number(e.currentTarget.value))
+                  }
+                />
 
-          {totalStems > 1 &&
-            <Button
-              name='Remove Stem'
-              value='Remove Stem'
-              disabled={false}
-              onClick={() => {removeExistingStem(stems[index].id, updateStems.removeObject)}}
-            />
-          }
+                <NumberInput
+                  name='Angle (degrees)'
+                  value={stem.angle}
+                  type='number'
+                  step={1}
+                  min={-35}
+                  max={35}
+                  onChange={(e: JSX.TargetedEvent<HTMLInputElement>) => 
+                    updateStems.updateField(stem.id, 'angle', Number(e.currentTarget.value))
+                  }
+                />
+
+                <NumberInput 
+                  name='Stack Height (mm)'
+                  value={stem.stackHeight}
+                  type='number'
+                  step={1}
+                  min={0}
+                  max={50}
+                  onChange={(e: JSX.TargetedEvent<HTMLInputElement>) => 
+                    updateStems.updateField(stem.id, 'stackHeight', Number(e.currentTarget.value))
+                  }
+                />
+
+                {totalStems > 1 &&
+                  <Button
+                    name='Remove this stem'
+                    value='Remove this stem'
+                    disabled={false}
+                    onClick={() => {removeExistingStem(stems[index].id, updateStems.removeObject)}}
+                  />
+                }
+              </div>
+            ))}
+          </div>
         </div>
-      ))}
-      
+        {frames.length > 1 &&
+          <div class="control-panel frame-buttons">
+            {frames.map((frame, index) => (
+              <Button
+                key={frame.id}
+                name={frame.id}
+                value={frame.name ? frame.name : `Frame ${frame.id.split('-')[1]}`}
+                disabled={frame.active}
+                onClick={() => setClickedElementId(frame.id)}
+              />
+            ))}
+          </div>
+        }
+
+        <div class="control-panel control-buttons">
+          <Button
+            name='New Frame'
+            value='New Frame'
+            disabled={frames.length >= 2}
+            onClick={(e) => {initializeNewElement('frame', frames, updateFrames.updateObject)}}
+          />
+
+          <Button
+            name='New Stem'
+            value='New Stem'
+            disabled={stems.length >= 3}
+            onClick={(e) => {initializeNewElement('stem', stems, updateStems.updateObject)}}
+          />
+        </div>
     </div>
   )
 }

--- a/src/client/components/Workspace/Workspace.tsx
+++ b/src/client/components/Workspace/Workspace.tsx
@@ -10,21 +10,23 @@ import { getStemTheme } from '../../utils/drawings';
 const Workspace: FunctionComponent<WorkspaceProps> = ({
   stems,
   updateStems,
-  frame,
-  updateFrame,
+  frames,
+  updateFrames,
   gridSize,
   gridCenter,
   gridRatio,
+  setClickedElementId,
 }) => {
   const totalStems = stems.length;
-
+  const activeFrame = frames.length > 1 ? frames.find(frame=> frame.active) : frames[0];
   return (
-  <div>
+  <div className="workspace-panel">
       <ControlPanel
         stems={stems}
-        frame={frame}
+        frames={frames}
         updateStems={updateStems}
-        updateFrame={updateFrame}
+        updateFrames={updateFrames}
+        setClickedElementId={setClickedElementId}
       />
 
     <svg width={gridSize} height={gridSize} className='cartesian-svg'>
@@ -40,7 +42,7 @@ const Workspace: FunctionComponent<WorkspaceProps> = ({
           key={index}
           stem={stem}
           theme={getStemTheme(totalStems, index)}
-          frame={frame}
+          frame={activeFrame}
           config={Thomson}
           gridSize={gridSize}
           gridCenter={gridCenter}

--- a/src/client/components/Workspace/WorkspaceTypes.ts
+++ b/src/client/components/Workspace/WorkspaceTypes.ts
@@ -8,18 +8,20 @@ export interface GridProps {
 }
 
 export interface WorkspaceProps {
-  stem: StemStateObjProps;
-  frame: FrameStateObjProps;
+  stems: StemStateObjProps[];
+  frames: FrameStateObjProps[];
   gridSize: number;
   gridCenter: number;
   gridRatio: number;
   updateStems: UpdateFunction<StemStateObjProps>;
-  updateFrame: UpdateFunction<FrameStateObjProps>;
+  updateFrames: UpdateFunction<FrameStateObjProps>;
+  setClickedElementId: (id: string | null) => void;
 }
 
 export interface ControlPanelProps {
   stems: StemStateObjProps[];
-  frame: FrameStateObjProps;
+  frames: FrameStateObjProps[];
   updateStems: UpdateFunction<StemStateObjProps>;
-  updateFrame: UpdateFunction<FrameStateObjProps>;
+  updateFrames: UpdateFunction<FrameStateObjProps>;
+  setClickedElementId: (id: string | null) => void;
 }

--- a/src/client/components/inputs/InputTypes.ts
+++ b/src/client/components/inputs/InputTypes.ts
@@ -1,12 +1,19 @@
 import { JSX } from "preact/jsx-runtime";
 
-export interface TextInputProps {
+export interface NumberInputProps {
   name: string;
-  value: string | number;
+  value: number;
   type: string;
   step: number;
   min: number;
   max: number;
+  onChange: (e: JSX.TargetedEvent<HTMLInputElement, Event>) => void;
+}
+
+export interface TextInputProps {
+  name: string;
+  value: string | number | undefined;
+  type: string;
   onChange: (e: JSX.TargetedEvent<HTMLInputElement, Event>) => void;
 }
 

--- a/src/client/components/inputs/NumberInput.tsx
+++ b/src/client/components/inputs/NumberInput.tsx
@@ -1,10 +1,13 @@
 import { FunctionComponent } from 'preact';
-import { TextInputProps } from './InputTypes';
+import { NumberInputProps } from './InputTypes';
 
-const TextInput: FunctionComponent<TextInputProps> = ({
+const NumberInput: FunctionComponent<NumberInputProps> = ({
   name,
   value,
   type,
+  step,
+  min,
+  max,
   onChange
 }) => {
 
@@ -15,10 +18,13 @@ const TextInput: FunctionComponent<TextInputProps> = ({
         type={type}
         value={value}
         name={name}
+        step={step}
+        min={min}
+        max={max}
         onChange={onChange}
       />
     </div>
   )
 }
 
-export default TextInput;
+export default NumberInput;

--- a/src/client/configs/defaults.ts
+++ b/src/client/configs/defaults.ts
@@ -1,4 +1,4 @@
-import { StemStateObjProps } from "../../types";
+import { FrameStateObjProps, StemStateObjProps } from "../../types";
 
 export const StemColors = {
   single: '#000000',
@@ -8,7 +8,15 @@ export const StemColors = {
 export const NewStem: StemStateObjProps = {
   angle: 0,
   id: 'stem-0',
+  name: '',
   length: 100,
   stackHeight: 0,
   color: '#000000',
+}
+
+export const NewFrame: FrameStateObjProps = {
+  id: 'frame-0',
+  active: false,
+  name: '',
+  headtubeAngle: 73,
 }

--- a/src/client/utils/calculations.tsx
+++ b/src/client/utils/calculations.tsx
@@ -31,17 +31,18 @@ export const calculateStemReach = (length: number, angleInDegrees: number): numb
  */
 
 export const calculateStackOffset = (
-  stackHeight: number, 
-  headtubeAngle: number, 
+  stackHeight: number,
+  headtubeAngle: number
 ): XYCoordinateProps => {
-  const angleInRadians = ((90 - headtubeAngle) * Math.PI / 100);
-  const offset = convertMmToPixels(stackHeight);
+  const angleInRadians = ((90 - headtubeAngle) * Math.PI) / 180;
+  // Adjust this scaling factor as needed
+  const scalingFactor = 3; // This might need fine-tuning
+  const offset = stackHeight * scalingFactor;
 
   return {
     x: -(Math.sin(angleInRadians) * offset),
-    y: -(Math.cos(angleInRadians) * offset)
+    y: -(Math.cos(angleInRadians) * offset),
   };
-   
 };
 
 /**

--- a/src/client/utils/drawings.tsx
+++ b/src/client/utils/drawings.tsx
@@ -16,34 +16,37 @@ export const drawSpacersOnScreen = (totalHeight: number): number[] => {
   const spacers: number[] = [];
 
   // Add as many x-large (max) spacers to the stack (20mm)
-  if (totalHeight >=  20) {
-    const count = Math.floor(totalHeight / 20);
-    spacers.push(...new Array(count).fill(20));
-    totalHeight -= count * 20;
+  while (totalHeight >= 20) {
+    spacers.push(20);
+    totalHeight -= 20;
   }
 
-  // Determine if any large spacers can be added (10mm)
-  if (totalHeight === 10) {
+  // Add a large spacer (10mm) if possible
+  if (totalHeight >= 10) {
     spacers.push(10);
     totalHeight -= 10;
   }
 
-  // Determine if any medium spacers can be added (5mm)
-  spacers.push(...getSpacersForSize(5, totalHeight));
-  totalHeight %= 5;
+  // Add medium spacers (5mm)
+  while (totalHeight >= 5) {
+    spacers.push(5);
+    totalHeight -= 5;
+  }
 
-  // Determine if any small spacers can be added (3mm)
-  if (totalHeight >= 3 && !spacers.includes(3)) {
+  // Add a small spacer (3mm) if possible
+  if (totalHeight >= 3) {
     spacers.push(3);
     totalHeight -= 3;
   }
 
   // Fill remaining stack height with x-small spacers (1mm)
-  spacers.push(...new Array(totalHeight).fill(1));
+  while (totalHeight > 0) {
+    spacers.push(1);
+    totalHeight -= 1;
+  }
 
   return spacers.sort((a, b) => a - b);
 };
-
 /**
  * Applies a slight Bézier curve to the conneciton points of the stem body when the angle
  * becomes extreme. This smooths out the connection point on the stem collar.

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -13,16 +13,23 @@ export interface StemConfigProps {
   diagrams: StemConfigDiagram
 }
 
+export type ElementType = 'frame' | 'stem';
+
 export interface StemStateObjProps {
   angle: number;
   id: string;
+  name?: string,
   length: number;
   stackHeight: number;
   color: string;
+  active?: boolean
 }
 
 export interface FrameStateObjProps {
   id: string;
+  active: boolean;
+  name?: string;
+  color?: string;
   headtubeAngle: number;
 }
 


### PR DESCRIPTION
- Adds the ability to hot-swap between framesets (max of 2). This allows you to test up to 3 stems, and quickly swap their tilt (ht angle) between each other.
- Adds the ability to account for spacer stack, when comparing multiple stems, stackheight spacers will now appear higher than default. This maxes out at 50mm, where 1 grid square is 10x10mm.
- Adds a slightly better UI, still mainly just focused on nailing the functionality right now

![Screen Shot 2025-01-28 at 1 26 10 AM](https://github.com/user-attachments/assets/fff8ecb0-eb4a-4651-8b49-f15b51b1c4b4)

![Screen Shot 2025-01-28 at 1 28 35 AM](https://github.com/user-attachments/assets/e5417c3e-f575-4cfa-84c1-abe98d64cd7f)

Spacers will also stack in realistic increments - see below. This is done to mimic how cyclists often stack multiple spacers
![Screen Shot 2025-01-28 at 1 29 34 AM](https://github.com/user-attachments/assets/268e7884-cf59-48b6-be90-6edf7c7a7c99)

Spacers generally come in 1, 3, 5, 10, 20mm increments, aside from some specialty outliers. To solve for the common denominator, there is some math that determines what would be the largest spacer and stacks accordingly

1mm -> 1x 1mm spacer
2mm -> 2x 1mm spacer
3mm -> 1x 3mm spacer
4mm -> 1x 3mm + 1x 1mm spacer
5mm -> 1x 5mm spacer
....
continuing on with the next "large" spacer breakpoint being 10 and 20. The maxed out stack height will visualize 2x 20mm + 1x 10mm spacer.


